### PR TITLE
size_t is defined in stddef.h

### DIFF
--- a/ext/zstd/varint.h
+++ b/ext/zstd/varint.h
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include <stddef.h>
 
 size_t varint_encoded_size(uint64_t value);
 


### PR DESCRIPTION
`rake compile` fails with "unknown type name size_t"
